### PR TITLE
Fixes for Arc and Circle intersections

### DIFF
--- a/lib/IntersectionParams.js
+++ b/lib/IntersectionParams.js
@@ -55,7 +55,6 @@ function getArcParameters(startPoint, endPoint, rx, ry, angle, arcFlag, sweepFla
     var ycr1 = (y1p - cyp) / ry;
     var ycr2 = (y1p + cyp) / ry;
 
-    var vcr1 = new Vector2D(1, 0);
     var theta1 = radian(1.0, 0.0, xcr1, ycr1);
 
     var deltaTheta = radian(xcr1, ycr1, -xcr2, -ycr2);
@@ -559,42 +558,14 @@ AbsoluteArcPath.prototype.init = function(command, params, previous) {
     this.sweepFlag = parseFloat(params.shift());
 };
 AbsoluteArcPath.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Ellipse", [this.getCenter(), this.rx, this.ry]);
+    return IntersectionParams.newArc(this.previous.getLastPoint(),
+                                     this.points[0],
+                                     this.rx,
+                                     this.ry,
+                                     this.angle,
+                                     this.arcFlag,
+                                     this.sweepFlag);
 };
-AbsoluteArcPath.prototype.getCenter = function() {
-    var startPoint = this.previous.getLastPoint();
-    var endPoint = this.points[0];
-    var rx = this.rx;
-    var ry = this.ry;
-    var angle = this.angle * Math.PI / 180;
-    var c = Math.cos(angle);
-    var s = Math.sin(angle);
-    var TOLERANCE = 1e-6;
-    var halfDiff = startPoint.subtract(endPoint).divide(2);
-    var x1p = halfDiff.x * c + halfDiff.y * s;
-    var y1p = halfDiff.x * -s + halfDiff.y * c;
-    var x1px1p = x1p * x1p;
-    var y1py1p = y1p * y1p;
-    var lambda = (x1px1p / (rx * rx)) + (y1py1p / (ry * ry));
-    if (lambda > 1) {
-        var factor = Math.sqrt(lambda);
-        rx *= factor;
-        ry *= factor;
-    }
-    var rxrx = rx * rx;
-    var ryry = ry * ry;
-    var rxy1 = rxrx * y1py1p;
-    var ryx1 = ryry * x1px1p;
-    var factor = (rxrx * ryry - rxy1 - ryx1) / (rxy1 + ryx1);
-    if (Math.abs(factor) < TOLERANCE) factor = 0;
-    var sq = Math.sqrt(factor);
-    if (this.arcFlag == this.sweepFlag) sq = -sq;
-    var mid = startPoint.add(endPoint).divide(2);
-    var cxp = sq * rx * y1p / ry;
-    var cyp = sq * -ry * x1p / rx;
-    return new Point2D(cxp * c - cyp * s + mid.x, cxp * s + cyp * c + mid.y);
-};
-
 
 
 function AbsoluteCurveto2(params, previous) {
@@ -607,7 +578,7 @@ AbsoluteCurveto2.prototype.constructor = AbsoluteCurveto2;
 AbsoluteCurveto2.superclass = AbsolutePathSegment.prototype;
 
 AbsoluteCurveto2.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Bezier2", [this.previous.getLastPoint(), this.points[0], this.points[1]]);
+    return IntersectionParams.newBezier2(this.previous.getLastPoint(), this.points[0], this.points[1]);
 };
 
 
@@ -625,7 +596,7 @@ AbsoluteCurveto3.prototype.getLastControlPoint = function() {
     return this.points[1];
 };
 AbsoluteCurveto3.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Bezier3", [this.previous.getLastPoint(), this.points[0], this.points[1], this.points[2]]);
+    return IntersectionParams.newBezier3(this.previous.getLastPoint(), this.points[0], this.points[1], this.points[2]);
 };
 
 
@@ -656,7 +627,7 @@ AbsoluteLineto.prototype.constructor = AbsoluteLineto;
 AbsoluteLineto.superclass = AbsolutePathSegment.prototype;
 
 AbsoluteLineto.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Line", [this.previous.getLastPoint(), this.points[0]]);
+    return IntersectionParams.newLine(this.previous.getLastPoint(), this.points[0]);
 };
 
 
@@ -693,7 +664,7 @@ AbsoluteSmoothCurveto2.prototype.getControlPoint = function() {
     return point;
 };
 AbsoluteSmoothCurveto2.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Bezier2", [this.previous.getLastPoint(), this.getControlPoint(), this.points[0]]);
+    return IntersectionParams.newBezier2(this.previous.getLastPoint(), this.getControlPoint(), this.points[0]);
 };
 
 
@@ -722,7 +693,7 @@ AbsoluteSmoothCurveto3.prototype.getLastControlPoint = function() {
     return this.points[0];
 };
 AbsoluteSmoothCurveto3.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Bezier3", [this.previous.getLastPoint(), this.getFirstControlPoint(), this.points[0], this.points[1]]);
+    return IntersectionParams.newBezier3(this.previous.getLastPoint(), this.getFirstControlPoint(), this.points[0], this.points[1]);
 };
 
 
@@ -769,7 +740,7 @@ RelativeClosePath.prototype.getLastPoint = function() {
     return point;
 };
 RelativeClosePath.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Line", [this.previous.getLastPoint(), this.getLastPoint()]);
+    return IntersectionParams.newLine(this.previous.getLastPoint(), this.getLastPoint());
 };
 
 
@@ -786,7 +757,7 @@ RelativeCurveto2.prototype.getControlPoint = function() {
     return this.points[0];
 };
 RelativeCurveto2.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Bezier2", [this.previous.getLastPoint(), this.points[0], this.points[1]]);
+    return IntersectionParams.newBezier2(this.previous.getLastPoint(), this.points[0], this.points[1]);
 };
 
 
@@ -803,7 +774,7 @@ RelativeCurveto3.prototype.getLastControlPoint = function() {
     return this.points[1];
 };
 RelativeCurveto3.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Bezier3", [this.previous.getLastPoint(), this.points[0], this.points[1], this.points[2]]);
+    return IntersectionParams.newBezier3(this.previous.getLastPoint(), this.points[0], this.points[1], this.points[2]);
 };
 
 
@@ -829,7 +800,7 @@ RelativeLineto.prototype.toString = function() {
     return cmd + point.toString();
 };
 RelativeLineto.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Line", [this.previous.getLastPoint(), this.points[0]]);
+    return IntersectionParams.newLine(this.previous.getLastPoint(), this.points[0]);
 };
 
 
@@ -867,7 +838,7 @@ RelativeSmoothCurveto2.prototype.getControlPoint = function() {
     return point;
 };
 RelativeSmoothCurveto2.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Bezier2", [this.previous.getLastPoint(), this.getControlPoint(), this.points[0]]);
+    return IntersectionParams.newBezier2(this.previous.getLastPoint(), this.getControlPoint(), this.points[0]);
 };
 
 
@@ -897,7 +868,7 @@ RelativeSmoothCurveto3.prototype.getLastControlPoint = function() {
     return this.points[0];
 };
 RelativeSmoothCurveto3.prototype.getIntersectionParams = function() {
-    return new IntersectionParams("Bezier3", [this.previous.getLastPoint(), this.getFirstControlPoint(), this.points[0], this.points[1]]);
+    return IntersectionParams.newBezier3(this.previous.getLastPoint(), this.getFirstControlPoint(), this.points[0], this.points[1]);
 };
 
 

--- a/lib/intersect.js
+++ b/lib/intersect.js
@@ -8,7 +8,7 @@
  *      @copyright 2015 Robert Benko (Quazistax) <quazistax@gmail.com>
  *      @license MIT
  */
- 
+
 var Point2D = require('kld-affine').Point2D;
 var Vector2D = require('kld-affine').Vector2D;
 var Matrix2D = require('kld-affine').Matrix2D;
@@ -134,7 +134,7 @@ function removeClosePoints(points1, points2) {
 // If you need to support bezier curves, plug in the functions/bezier module
 // like this: intersect.plugin( require('svg-intersections/lib/functions/bezier') )
 var intersectionFunctions = {
-            
+
     /**
         intersectPathShape
 
@@ -591,9 +591,9 @@ function intersect(shape1, shape2, m1, m2) {
                     c2 = new Point2D(0, 0);
                     rx2 = ry2 = 1;
 
-                    d2 = m1.inverse().multiply(m2).getDecompositionTRSR();
-                    m1_ = d2.R.inverse().multiply(d2.T.inverse());
-                    m2_ = d2.S;
+                    d2 = m1.inverse().multiply(m2).getDecomposition();
+                    m1_ = d2.rotation.inverse().multiply(d2.translation.inverse());
+                    m2_ = d2.scale;
 
                     rx2 = m2_.a;
                     ry2 = m2_.d;
@@ -699,6 +699,3 @@ intersect.plugin = function() {
 }
 
 module.exports = intersect;
-
- 
-

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "path"
   ],
   "dependencies": {
-    "kld-affine": "^0.1.0",
+    "kld-affine": "git+https://github.com/framespaces/kld-affine.git#development",
     "kld-polynomial": "https://github.com/thelonious/kld-polynomial.git#development"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "path"
   ],
   "dependencies": {
-    "kld-affine": "^2",
-    "kld-polynomial": "https://github.com/thelonious/kld-polynomial.git#development"
+    "kld-affine": "2.0.0",
+    "kld-polynomial": "0.1.1"
   },
   "devDependencies": {
     "expresso": "0.9.2"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "kld-affine": "^0.1.0",
-    "kld-polynomial": "^0.1.0"
+    "kld-polynomial": "https://github.com/thelonious/kld-polynomial.git#development"
   },
   "devDependencies": {
     "expresso": "0.9.2"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "path"
   ],
   "dependencies": {
-    "kld-affine": "git+https://github.com/framespaces/kld-affine.git#development",
+    "kld-affine": "^2",
     "kld-polynomial": "https://github.com/thelonious/kld-polynomial.git#development"
   },
   "devDependencies": {

--- a/test/intersection_tests.js
+++ b/test/intersection_tests.js
@@ -88,3 +88,13 @@ exports.testIntersectCircleCircle = function(beforeExit, assert) {
   assert.equal(result.points[1].x, 0);
   assert.equal(result.points[1].y, 1);
 }
+
+exports.testIntersectArcArc = function(beforeExit, assert) {
+  var arc1 = shape("path", {d: "M0 20 A 20 20, 0, 0, 0, 20 0"}); // Quarter circle around origin
+  var arc2 = shape("path", {d: "M0 0 A 20 20, 0, 0, 0, 20 20"}); // Quarter circle around 20,0
+  var result = intersect(arc1, arc2);
+
+  assert.equal(1, result.points.length);
+  assert.ok(Math.abs(result.points[0].x - 10) <= Number.EPSILON * 10);
+  assert.ok(Math.abs(result.points[0].y - 17) <= 1);
+}

--- a/test/intersection_tests.js
+++ b/test/intersection_tests.js
@@ -76,3 +76,15 @@ exports.testNoIntersectLargeArcLine = function(beforeExit, assert) {
 
   assert.equal(0, result.points.length);
 }
+
+exports.testIntersectCircleCircle = function(beforeExit, assert) {
+  var circle1 = shape("circle", {cx:0, cy:0, r:1});
+  var circle2 = shape("circle", {cx:1, cy:1, r:1});
+  var result = intersect(circle1, circle2);
+
+  assert.equal(2, result.points.length);
+  assert.equal(result.points[0].x, 1);
+  assert.equal(result.points[0].y, 0);
+  assert.equal(result.points[1].x, 0);
+  assert.equal(result.points[1].y, 1);
+}

--- a/test/intersection_tests.js
+++ b/test/intersection_tests.js
@@ -41,12 +41,38 @@ exports.testIntersectDiamondLine = function(beforeExit, assert) {
   assert.equal(result.points[0].equals(new Point2D(5.75, 5.75)), true);
 }
 
-exports.testIntersectArcLine = function(beforeExit, assert) {
-  var arc = shape("path", {d: "M0 20 A 20 20, 0, 0, 0, 20 0"});
-  var line = shape("line", {x1: 0, y1:0, x2:20, y2:20});
+exports.testIntersectSmallArcLine = function(beforeExit, assert) {
+  var arc = shape("path", {d: "M0 20 A 20 20, 0, 0, 0, 20 0"}); // Quarter circle around origin
+  var line = shape("line", {x1: 0, y1:0, x2:20, y2:20}); // Diagonal right-down
   var result = intersect(arc, line);
 
   assert.equal(1, result.points.length);
   assert.equal(result.points[0].distanceFrom(new Point2D(0, 0)), 20);
   assert.equal(result.points[0].x, result.points[0].y);
+}
+
+exports.testNoIntersectSmallArcLine = function(beforeExit, assert) {
+  var arc = shape("path", {d: "M0 20 A 20 20, 0, 0, 0, 20 0"}); // Quarter circle around origin
+  var line = shape("line", {x1: 0, y1:0, x2:20, y2:-20}); // Diagonal right-up
+  var result = intersect(arc, line);
+
+  assert.equal(0, result.points.length);
+}
+
+exports.testIntersectLargeArcLine = function(beforeExit, assert) {
+  var arc = shape("path", {d: "M0 20 A 20 20, 0, 1, 0, 20 0"}); // Three-quarter circle around 20,20
+  var line = shape("line", {x1: 0, y1:0, x2:40, y2:40}); // Diagonal right-down
+  var result = intersect(arc, line);
+
+  assert.equal(1, result.points.length);
+  assert.equal(result.points[0].distanceFrom(new Point2D(20, 20)), 20);
+  assert.equal(result.points[0].x, result.points[0].y);
+}
+
+exports.testNoIntersectLargeArcLine = function(beforeExit, assert) {
+  var arc = shape("path", {d: "M0 20 A 20 20, 0, 1, 0, 20 0"}); // Three-quarter circle around 20,20
+  var line = shape("line", {x1: 0, y1:0, x2:20, y2:20}); // Diagonal right-down
+  var result = intersect(arc, line);
+
+  assert.equal(0, result.points.length);
 }


### PR DESCRIPTION
Making use of the static methods on `IntersectionParams`. In particular, `newArc` behaves correctly with respect to large arcs (but required latest versions of the kld libraries). Trivially refactored the others while I was there, and added unit tests. Thanks!