### PR TITLE
Fix error

### DIFF
--- a/lib/functions/bezier.js
+++ b/lib/functions/bezier.js
@@ -19,11 +19,7 @@ function removeMultipleRootsIn01(roots) {
     }
 }
 
-module.exports = {
-  Utils: {
-    removeMultipleRootsIn01: removeMultipleRootsIn01
-  }
-};
+module.exports = {};
 
 /**
  *  intersectBezier2Bezier2
@@ -222,7 +218,7 @@ module.exports.intersectBezier2Bezier3 = function(a1, a2, a3, b1, b2, b3, b4) {
             c20x2*c12y2 + c12x2*c20y2
     );
     var roots = poly.getRootsInInterval(0,1);
-    module.exports.Utils.removeMultipleRootsIn01(roots);
+    removeMultipleRootsIn01(roots);
 
     for ( var i = 0; i < roots.length; i++ ) {
         var s = roots[i];
@@ -661,7 +657,7 @@ module.exports.intersectBezier3Bezier3 = function(a1, a2, a3, a4, b1, b2, b3, b4
             3*c20.x*c20y2*c13x2*c13.y - c20x2*c12.x*c12y2*c13.y - 3*c20x2*c20.y*c13.x*c13y2 + c12x2*c20y2*c12.y*c13.x
     );
     var roots = poly.getRootsInInterval(0,1);
-    module.exports.Utils.removeMultipleRootsIn01(roots);
+    removeMultipleRootsIn01(roots);
 
     for ( var i = 0; i < roots.length; i++ ) {
         var s = roots[i];
@@ -753,7 +749,7 @@ module.exports.intersectBezier3Ellipse = function(p1, p2, p3, p4, ec, rx, ry) {
             c0.y*c0.y*rxrx + ec.x*ec.x*ryry + ec.y*ec.y*rxrx - rxrx*ryry
     );
     var roots = poly.getRootsInInterval(0,1);
-    module.exports.Utils.removeMultipleRootsIn01(roots);
+    removeMultipleRootsIn01(roots);
 
     for ( var i = 0; i < roots.length; i++ ) {
         var t = roots[i];

--- a/lib/functions/bezier.js
+++ b/lib/functions/bezier.js
@@ -19,8 +19,11 @@ function removeMultipleRootsIn01(roots) {
     }
 }
 
-module.exports = {};
-
+module.exports = {
+  Utils: {
+    removeMultipleRootsIn01: removeMultipleRootsIn01
+  }
+};
 
 /**
  *  intersectBezier2Bezier2


### PR DESCRIPTION
When intersecting two paths, an error thrown: Cannot read property 'removeMultipleRootsIn01' of undefined. This PR fixes it by adding missing export. Other solution - this can be fixed by replacing module.exports.Utils.removeMultipleRootsIn01 with removeMultipleRootsIn01. (3 times)