### PR TITLE
Fix permalinks in "Credits" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ Credits
 -------
 
 The implementation is based on the intersection procedures by Kevin Lindsey 
-([http://www.kevlindev.com](www.kevlindev.com)) with contributions by 
-Robert Benko ([http://www.quazistax.com](www.quazistax.com)).
+([http://www.kevlindev.com](http://www.kevlindev.com)) with contributions by 
+Robert Benko ([http://www.quazistax.com](http://www.quazistax.com)).


### PR DESCRIPTION
Without the protocol GitHub treats these links as relative urls.